### PR TITLE
Made everything public to get rid of warnings

### DIFF
--- a/src/integer.rs
+++ b/src/integer.rs
@@ -1,16 +1,16 @@
 #[derive(Debug, PartialEq)]
 
-struct Int {
+pub struct Int {
     is_negative: bool,
     digits: Vec<u32>,
 }
 
 impl Int {
-    fn new(is_negative: bool, digits: Vec<u32>) -> Int {
+    pub fn new(is_negative: bool, digits: Vec<u32>) -> Int {
         Int { is_negative, digits }
     }
 
-    fn new_from_i32(num: i32) -> Int {
+    pub fn new_from_i32(num: i32) -> Int {
             Int { is_negative: num < 0, digits: vec![abs(num)] }
     }
 }


### PR DESCRIPTION
Stops warnings like this one
```
$ cargo test
   Compiling rust_number v0.1.0 (file:///Users/jlai052/github/rust_number)
warning: method is never used: `new`
 --> src/integer.rs:9:5
  |
9 |     fn new(is_negative: bool, digits: Vec<u32>) -> Int {
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: #[warn(dead_code)] on by default
```
by making everything public.